### PR TITLE
RVFitter can search over a temperature grid

### DIFF
--- a/Fitters.py
+++ b/Fitters.py
@@ -27,8 +27,7 @@ from astropy.modeling.polynomial import Chebyshev2D
 import FittingUtilities
 import DataStructures
 from HelperFunctions import IsListlike, ExtrapolatingUnivariateSpline, ensure_dir, fwhm
-
-
+##import pdb
 
 
 #from astropy.analytic_functions import blackbody_lambda as blackbody
@@ -477,12 +476,10 @@ if emcee_import:
             self.samples = None
             self.n_params = None
             self.param_names = None
-
             if param_names is not None:
                 self.n_params = len(param_names)
                 self.param_names = param_names
             return
-
 
         def model(self, p, x):
             """
@@ -1744,7 +1741,7 @@ class RVFitter(Bayesian_LS):
         vsini_guess = vsini_vals[np.argmax(max_ccf)]
 
         T_ff_guess, f_pars = self._fit_ff_teff(self.x, self.y, self.model_spec, rv_guess, vsini_guess, self._T)
-        self.guess_pars = [rv_guess, vsini_guess, 0.5, T_ff_guess, self._T]
+        self.guess_pars = [rv_guess, vsini_guess, 0.5, self._T, self._T]
 
         return self.guess_pars
 
@@ -1846,9 +1843,28 @@ class RVFitter(Bayesian_LS):
                 lnlike.append(lnl)
 
         return logg_grid[np.argmax(lnlike)]
+    
+    def _teff_logg_like(self,input_pars,rv=0.0, vsini=100,**kwargs):
+        self.update_model(Teff=input_pars[0], logg=input_pars[1], feh=self._feh)
+        flattened_orders = self.flatten_spectrum(plot=False, pars=(rv, vsini, 0.5, 3500, self._T))
+        # Find how well the orders overlap
+        lnl = 0.0
+        for i, left in enumerate(flattened_orders):
+            if i < len(flattened_orders) - 1:
+                right = flattened_orders[i + 1]
+                right_fcn = spline(right.x, right.y)
+                idx = left.x > right.x[0]
+                lnl += 0.5 * np.sum((left.y[idx] - right_fcn(left.x[idx])) ** 2)
+        return lnl
+            
+    
+    def _estimate_logg_teff(self, logg_lims=(3.0, 5.0),teff_range = 2000.0, rv=0.0, vsini=100,N=10, **kwargs):
+        teff_lims    = (np.max([self._T-teff_range/2,6000.0]),np.min([self._T+teff_range/2,30000.0]))
+        the_ranges   = [teff_lims,logg_lims]
+        bruteresults = brute(self._teff_logg_like,the_ranges,(rv,vsini),Ns=N,finish=None)      
+        return bruteresults[0],bruteresults[1]
 
-
-    def flatten_spectrum(self, plot=False, pars=None, return_lnlike=False, update_logg=False, **kwargs):
+    def flatten_spectrum(self, plot=False, pars=None, return_lnlike=False, update_logg=False, update_teff_logg=False, **kwargs):
         """
         Returns a flattened spectrum as a list of DataStructures.xypoint instances
         :return:
@@ -1867,7 +1883,16 @@ class RVFitter(Bayesian_LS):
             best_logg = self._estimate_logg(rv=pars[0], vsini=pars[1], **kwargs)
             logging.info('Best log(g) = {:.2f}'.format(best_logg))
             self.update_model(Teff=self._T, feh=self._feh, logg=best_logg)
-
+        if update_teff_logg:
+            logging.info('Estimating log(g) and Teff...')
+            best_teff,best_logg = self._estimate_logg_teff(rv=pars[0], vsini=pars[1], **kwargs)
+            logging.info('Best log(g) = {:.2f}'.format(best_logg))
+            logging.info('Best Teff   = {:.2f}'.format(best_teff))
+            self.update_model(Teff=best_teff, feh=self._feh, logg=best_logg)
+            logging.info('RE-Guessing inital RV and Vsini for updated logg and Teff')
+            pars = self.guess_fit_parameters(**kwargs)
+            print(pars)
+            
         # Get the model orders and scale factor
         model_orders = self.model(pars, self.x)
         scale_factor = self._fit_factor(self.x, model_orders, self.y)
@@ -1884,10 +1909,9 @@ class RVFitter(Bayesian_LS):
             ff_bb = blackbody(xi * u.nm.to(u.cm), Tff)
 
             cont = RobustFit(xi, yi / model, 2)
-
+			
             normed = yi * (ff_bb / prim_bb) / cont
             normed_err = yi_err * (ff_bb / prim_bb) / cont
-
             if plot:
                 ax.plot(xi, normed, alpha=0.5)
                 ax.plot(xi, model * ff_bb / prim_bb, 'k-', lw=1)

--- a/Fitters.py
+++ b/Fitters.py
@@ -1630,7 +1630,7 @@ class RVFitter(Bayesian_LS):
 
         model_orders = []
         for xi in x:
-            mi = fcn(xi*(1+rv/self._clight))
+            mi = fcn(xi*(1-rv/self._clight))
             if estimate_bb_fluxes:
                 prim_bb = blackbody(xi * u.nm.to(u.cm), Tsource)
                 ff_bb = blackbody(xi * u.nm.to(u.cm), Tff)
@@ -1737,7 +1737,7 @@ class RVFitter(Bayesian_LS):
             idx = np.argmax(ccf.y)
             max_ccf[i] = ccf.y[idx]
             max_vel[i] = ccf.x[idx]
-        rv_guess = max_vel[np.argmax(max_ccf)]
+        rv_guess = -max_vel[np.argmax(max_ccf)]
         vsini_guess = vsini_vals[np.argmax(max_ccf)]
 
         T_ff_guess, f_pars = self._fit_ff_teff(self.x, self.y, self.model_spec, rv_guess, vsini_guess, self._T)
@@ -1858,7 +1858,7 @@ class RVFitter(Bayesian_LS):
         return lnl
             
     
-    def _estimate_logg_teff(self, logg_lims=(3.0, 5.0),teff_range = 2000.0, rv=0.0, vsini=100,N=10, **kwargs):
+    def _estimate_logg_teff(self, logg_lims=(3.0, 5.0),teff_range = 1000.0, rv=0.0, vsini=100,N=10, **kwargs):
         teff_lims    = (np.max([self._T-teff_range/2,6000.0]),np.min([self._T+teff_range/2,30000.0]))
         the_ranges   = [teff_lims,logg_lims]
         bruteresults = brute(self._teff_logg_like,the_ranges,(rv,vsini),Ns=N,finish=None)      

--- a/Fitters.py
+++ b/Fitters.py
@@ -1844,9 +1844,10 @@ class RVFitter(Bayesian_LS):
 
         return logg_grid[np.argmax(lnlike)]
     
-    def _teff_logg_like(self,input_pars,rv=0.0, vsini=100,**kwargs):
+    def _teff_logg_like(self, input_pars, rv=0.0, vsini=100, **kwargs):
         self.update_model(Teff=input_pars[0], logg=input_pars[1], feh=self._feh)
         flattened_orders = self.flatten_spectrum(plot=False, pars=(rv, vsini, 0.5, 3500, self._T))
+
         # Find how well the orders overlap
         lnl = 0.0
         for i, left in enumerate(flattened_orders):
@@ -1858,11 +1859,12 @@ class RVFitter(Bayesian_LS):
         return lnl
             
     
-    def _estimate_logg_teff(self, logg_lims=(3.0, 5.0),teff_range = 1000.0, rv=0.0, vsini=100,N=10, **kwargs):
-        teff_lims    = (np.max([self._T-teff_range/2,6000.0]),np.min([self._T+teff_range/2,30000.0]))
-        the_ranges   = [teff_lims,logg_lims]
-        bruteresults = brute(self._teff_logg_like,the_ranges,(rv,vsini),Ns=N,finish=None)      
-        return bruteresults[0],bruteresults[1]
+    def _estimate_logg_teff(self, logg_lims=(3.0, 5.0), teff_range=1000.0, rv=0.0, vsini=100, N=10, **kwargs):
+        teff_lims    = (np.max([self._T-teff_range/2,6000.0]), np.min([self._T+teff_range/2,30000.0]))
+        the_ranges   = [teff_lims, logg_lims]
+        bruteresults = brute(self._teff_logg_like, the_ranges, (rv,vsini), Ns=N, finish=None)      
+        return bruteresults[0], bruteresults[1]
+        
 
     def flatten_spectrum(self, plot=False, pars=None, return_lnlike=False, update_logg=False, update_teff_logg=False, **kwargs):
         """
@@ -1878,11 +1880,14 @@ class RVFitter(Bayesian_LS):
                 pars = self.guess_fit_parameters(**kwargs)
             print(pars)
 
-        if update_logg:
+        if update_logg and not update_teff_logg:
             logging.info('Estimating log(g)...')
             best_logg = self._estimate_logg(rv=pars[0], vsini=pars[1], **kwargs)
             logging.info('Best log(g) = {:.2f}'.format(best_logg))
             self.update_model(Teff=self._T, feh=self._feh, logg=best_logg)
+            logging.info('RE-Guessing inital RV and Vsini for updated logg')
+            pars = self.guess_fit_parameters(**kwargs)
+
         if update_teff_logg:
             logging.info('Estimating log(g) and Teff...')
             best_teff,best_logg = self._estimate_logg_teff(rv=pars[0], vsini=pars[1], **kwargs)


### PR DESCRIPTION
Aaron and I updated RVFitter to search over a temperature grid as well as a log(g) grid when flattening spectra. It works well in the low-ish to moderate signal-to-noise ratio data, but the models are not good enough for very high S/N data.
